### PR TITLE
Rename comment command to remark in header.tex

### DIFF
--- a/header.tex
+++ b/header.tex
@@ -134,9 +134,9 @@
 \newcommand{\todo}[1]{{\color{red}\nota{TODO}{#1}}} % important: Remove spacing before and after \todo{}
 % uncomment the following line to hide all \todo{} commands
 %\renewcommand\todo[1]{}
-\newcommand{\comment}[2]{{\color{blue}\nota{#1}{#2}}} % important: Remove spacing before and after \todo{}
-% uncomment the following line to hide all \todo{} commands
-%\renewcommand\comment[1]{}
+\newcommand{\remark}[2]{{\color{blue}\nota{#1}{#2}}} % important: Remove spacing before and after \todo{}
+% uncomment the following line to hide all \remark{} commands
+%\renewcommand\remark[2]{}
 
 % customize links and references
 \usepackage[hyphens]{url} % line breaks in URLs


### PR DESCRIPTION
Using \comment does not generate an error, but all the text or commands after \comment are not executed. \comment seems to be reserved. \renewcommand\remark must have two arguments, otherwise the comment text will still be visible.